### PR TITLE
Added missing facility constants from RFC3164, part 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,23 +120,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <configuration>
-                    <keyname>B1606F22</keyname>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
@@ -227,6 +210,30 @@
             <properties>
                 <additionalparam>-Xdoclint:none</additionalparam>
             </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <configuration>
+                            <keyname>B1606F22</keyname>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
+++ b/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
@@ -88,6 +88,14 @@ public interface SyslogConstants extends Serializable {
     public static final int FACILITY_AUTHPRIV = 10 << 3;
     public static final int FACILITY_FTP = 11 << 3;
 
+    // add constants according to
+    // The BSD syslog Protocol, 4.1.1 PRI Part
+    // https://www.ietf.org/rfc/rfc3164.txt
+    public static final int FACILITY_NTP = 12 << 3;
+    public static final int FACILITY_AUDIT = 13 << 3;
+    public static final int FACILITY_ALERT = 14 << 3;
+    public static final int FACILITY_CLOCK2 = 15 << 3;
+
     public static final int FACILITY_LOCAL0 = 16 << 3;
     public static final int FACILITY_LOCAL1 = 17 << 3;
     public static final int FACILITY_LOCAL2 = 18 << 3;

--- a/src/main/java/org/graylog2/syslog4j/util/SyslogUtility.java
+++ b/src/main/java/org/graylog2/syslog4j/util/SyslogUtility.java
@@ -65,6 +65,14 @@ public final class SyslogUtility implements SyslogConstants {
                 return "authpriv";
             case FACILITY_FTP:
                 return "ftp";
+            case FACILITY_NTP:
+                return "ntp";
+            case FACILITY_AUDIT:
+                return "audit";
+            case FACILITY_ALERT:
+                return "alert";
+            case FACILITY_CLOCK2:
+                return "clock2";
             case FACILITY_LOCAL0:
                 return "local0";
             case FACILITY_LOCAL1:
@@ -88,54 +96,59 @@ public final class SyslogUtility implements SyslogConstants {
     }
 
     public static final int getFacility(String facilityName) {
-        String _facilityName = facilityName;
 
         if (facilityName == null) {
             return -1;
-
-        } else {
-            _facilityName = facilityName.trim();
         }
+        String _facilityName = facilityName.trim();
 
         if ("KERN".equalsIgnoreCase(_facilityName)) {
             return FACILITY_KERN;
-        } else if ("USER".equalsIgnoreCase(facilityName)) {
+        } else if ("USER".equalsIgnoreCase(_facilityName)) {
             return FACILITY_USER;
-        } else if ("MAIL".equalsIgnoreCase(facilityName)) {
+        } else if ("MAIL".equalsIgnoreCase(_facilityName)) {
             return FACILITY_MAIL;
-        } else if ("DAEMON".equalsIgnoreCase(facilityName)) {
+        } else if ("DAEMON".equalsIgnoreCase(_facilityName)) {
             return FACILITY_DAEMON;
-        } else if ("AUTH".equalsIgnoreCase(facilityName)) {
+        } else if ("AUTH".equalsIgnoreCase(_facilityName)) {
             return FACILITY_AUTH;
-        } else if ("SYSLOG".equalsIgnoreCase(facilityName)) {
+        } else if ("SYSLOG".equalsIgnoreCase(_facilityName)) {
             return FACILITY_SYSLOG;
-        } else if ("LPR".equalsIgnoreCase(facilityName)) {
+        } else if ("LPR".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LPR;
-        } else if ("NEWS".equalsIgnoreCase(facilityName)) {
+        } else if ("NEWS".equalsIgnoreCase(_facilityName)) {
             return FACILITY_NEWS;
-        } else if ("UUCP".equalsIgnoreCase(facilityName)) {
+        } else if ("UUCP".equalsIgnoreCase(_facilityName)) {
             return FACILITY_UUCP;
-        } else if ("CRON".equalsIgnoreCase(facilityName)) {
+        } else if ("CRON".equalsIgnoreCase(_facilityName)) {
             return FACILITY_CRON;
-        } else if ("AUTHPRIV".equalsIgnoreCase(facilityName)) {
+        } else if ("AUTHPRIV".equalsIgnoreCase(_facilityName)) {
             return FACILITY_AUTHPRIV;
-        } else if ("FTP".equalsIgnoreCase(facilityName)) {
+        } else if ("FTP".equalsIgnoreCase(_facilityName)) {
             return FACILITY_FTP;
-        } else if ("LOCAL0".equalsIgnoreCase(facilityName)) {
+        } else if ("NTP".equalsIgnoreCase(_facilityName)) {
+            return FACILITY_NTP;
+        } else if ("AUDIT".equalsIgnoreCase(_facilityName)) {
+            return FACILITY_AUDIT;
+        } else if ("ALERT".equalsIgnoreCase(_facilityName)) {
+            return FACILITY_ALERT;
+        } else if ("CLOCK2".equalsIgnoreCase(_facilityName)) {
+            return FACILITY_CLOCK2;
+        } else if ("LOCAL0".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL0;
-        } else if ("LOCAL1".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL1".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL1;
-        } else if ("LOCAL2".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL2".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL2;
-        } else if ("LOCAL3".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL3".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL3;
-        } else if ("LOCAL4".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL4".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL4;
-        } else if ("LOCAL5".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL5".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL5;
-        } else if ("LOCAL6".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL6".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL6;
-        } else if ("LOCAL7".equalsIgnoreCase(facilityName)) {
+        } else if ("LOCAL7".equalsIgnoreCase(_facilityName)) {
             return FACILITY_LOCAL7;
         } else {
             return -1;
@@ -143,14 +156,10 @@ public final class SyslogUtility implements SyslogConstants {
     }
 
     public static final int getLevel(String levelName) {
-        String _levelName = levelName;
-
         if (levelName == null) {
             return -1;
-
-        } else {
-            _levelName = levelName.trim();
         }
+        String _levelName = levelName.trim();
 
         if ("DEBUG".equalsIgnoreCase(_levelName)) {
             return LEVEL_DEBUG;

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEventTest.java
@@ -100,4 +100,69 @@ public class SyslogServerEventTest {
         assertEquals(event.getLevel(), 5);
         assertEquals(event.getMessage(), "10.0.0.99 Use the BFG!");
     }
+
+    @Test
+    public void testFacility12() throws Exception {
+        // Message from: https://tools.ietf.org/html/rfc3164#section-5.4
+        // Added pid to program.
+        // changed facility to 12
+        final String message = "<98>Oct 11 22:14:15 mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8";
+
+        final SyslogServerEvent event = buildEvent(message);
+
+        assertEquals(event.getDate(), new DateTime(new DateTime().getYear() + "-10-11T22:14:15").toDate());
+        assertEquals(event.getFacility(), 12);
+        assertEquals(event.getHost(), "mymachine");
+        assertEquals(event.getLevel(), 2);
+        assertEquals(event.getMessage(), "mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8");
+    }
+
+    @Test
+    public void testFacility13() throws Exception {
+        // Message from: https://tools.ietf.org/html/rfc3164#section-5.4
+        // Added pid to program.
+        // changed facility to 13
+        final String message = "<106>Oct 11 22:14:15 mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8";
+
+        final SyslogServerEvent event = buildEvent(message);
+
+        assertEquals(event.getDate(), new DateTime(new DateTime().getYear() + "-10-11T22:14:15").toDate());
+        assertEquals(event.getFacility(), 13);
+        assertEquals(event.getHost(), "mymachine");
+        assertEquals(event.getLevel(), 2);
+        assertEquals(event.getMessage(), "mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8");
+    }
+
+    @Test
+    public void testFacility14() throws Exception {
+        // Message from: https://tools.ietf.org/html/rfc3164#section-5.4
+        // Added pid to program.
+        // changed facility to 14
+        final String message = "<114>Oct 11 22:14:15 mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8";
+
+        final SyslogServerEvent event = buildEvent(message);
+
+        assertEquals(event.getDate(), new DateTime(new DateTime().getYear() + "-10-11T22:14:15").toDate());
+        assertEquals(event.getFacility(), 14);
+        assertEquals(event.getHost(), "mymachine");
+        assertEquals(event.getLevel(), 2);
+        assertEquals(event.getMessage(), "mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8");
+    }
+
+    @Test
+    public void testFacility15() throws Exception {
+        // Message from: https://tools.ietf.org/html/rfc3164#section-5.4
+        // Added pid to program.
+        // changed facility to 15
+        final String message = "<122>Oct 11 22:14:15 mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8";
+
+        final SyslogServerEvent event = buildEvent(message);
+
+        assertEquals(event.getDate(), new DateTime(new DateTime().getYear() + "-10-11T22:14:15").toDate());
+        assertEquals(event.getFacility(), 15);
+        assertEquals(event.getHost(), "mymachine");
+        assertEquals(event.getLevel(), 2);
+        assertEquals(event.getMessage(), "mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8");
+    }
+
 }


### PR DESCRIPTION
* This pull request adds the missing constants from RFC3164, part 4.1.1
* In addition, I did some "fixes" on `getFacility` and `getSeverity` (redundant / inconsistent code)
* I added unit tests for the newly added syslog facilities
* This would resolve #2 