### PR TITLE
Fix parsing of empty RFC5424 structured data in a message.

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/impl/message/structured/StructuredSyslogMessage.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/message/structured/StructuredSyslogMessage.java
@@ -31,6 +31,9 @@ import java.util.Set;
  * @version $Id: StructuredSyslogMessage.java,v 1.5 2010/09/11 16:49:24 cvs Exp $
  */
 public class StructuredSyslogMessage extends AbstractSyslogMessage implements StructuredSyslogMessageIF {
+    public static final String EMPTY_STRUCTURED_DATA_PREFIX = "- - ";
+    public static final int EMPTY_STRUCTURED_DATA_PREFIX_LENGTH = EMPTY_STRUCTURED_DATA_PREFIX.length();
+
     private String messageId;
     private Map<String, Map<String, String>> structuredData;
     private String message;
@@ -83,6 +86,14 @@ public class StructuredSyslogMessage extends AbstractSyslogMessage implements St
     }
 
     private void  deserialize(final String stringMessage) {
+
+        // Check if the RFC5424 MSGID and STRUCTURED-DATA fields are empty.
+        // This avoids throwing an exception and also strips the "- - " from the message.
+        // See: https://github.com/Graylog2/graylog2-server/issues/1161
+        if (stringMessage.startsWith(EMPTY_STRUCTURED_DATA_PREFIX)) {
+            this.message = stringMessage.substring(EMPTY_STRUCTURED_DATA_PREFIX_LENGTH);
+            return;
+        }
 
         int start = stringMessage.indexOf('[');
         int end = -1;  

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEventTest.java
@@ -101,7 +101,7 @@ public class StructuredSyslogServerEventTest {
 
         assertEquals(null, event.getStructuredMessage().getStructuredData());
         assertEquals(null, event.getStructuredMessage().getMessageId());
-        assertEquals("- - tralala", event.getStructuredMessage().getMessage());
+        assertEquals("tralala", event.getStructuredMessage().getMessage());
     }
 
     @Test
@@ -160,7 +160,7 @@ public class StructuredSyslogServerEventTest {
 
         assertEquals(null, event.getStructuredMessage().getStructuredData());
         assertEquals(null, event.getStructuredMessage().getMessageId());
-        assertEquals("- - %% It's time to make the do-nuts.", event.getStructuredMessage().getMessage());
+        assertEquals("%% It's time to make the do-nuts.", event.getStructuredMessage().getMessage());
     }
 
     @Test


### PR DESCRIPTION
This avoids throwing an exception and also strips the `- - ` from the resulting message.

Refs Graylog2/graylog2-server#1161