### PR TITLE
Implemented compatibility with frame header.

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
+++ b/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
@@ -24,6 +24,9 @@ public interface SyslogConstants extends Serializable {
 
     public static final String STRUCTURED_DATA_NILVALUE = "-";
     public static final String STRUCTURED_DATA_EMPTY_VALUE = "[0@0]";
+    public static final String SYSLOG_DATEFORMAT_RFC5424  = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    public static final int    MAX_MESSAGE_LENGTH_RFC5424 =  2048;
+    public static final int    MIN_MESSAGE_LENGTH_RFC5424 =  480;
 
     public static final String CHAR_SET_DEFAULT = "UTF-8";
 

--- a/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
+++ b/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
@@ -26,7 +26,6 @@ public interface SyslogConstants extends Serializable {
     public static final String STRUCTURED_DATA_EMPTY_VALUE = "[0@0]";
     public static final String SYSLOG_DATEFORMAT_RFC5424  = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     public static final int    MAX_MESSAGE_LENGTH_RFC5424 =  2048;
-    public static final int    MIN_MESSAGE_LENGTH_RFC5424 =  480;
 
     public static final String CHAR_SET_DEFAULT = "UTF-8";
 

--- a/src/main/java/org/graylog2/syslog4j/SyslogIF.java
+++ b/src/main/java/org/graylog2/syslog4j/SyslogIF.java
@@ -1,5 +1,7 @@
 package org.graylog2.syslog4j;
 
+import java.util.Date;
+
 /**
  * SyslogIF provides a common interface for all Syslog4j client implementations.
  * <p/>
@@ -20,8 +22,10 @@ public interface SyslogIF extends SyslogConstants {
     public void backLog(int level, String message, Throwable reasonThrowable);
 
     public void backLog(int level, String message, String reason);
-
+    
     public void log(int level, String message);
+
+    public void log(int level, String message, Date datetime);
 
     public void debug(String message);
 

--- a/src/main/java/org/graylog2/syslog4j/SyslogMessageProcessorIF.java
+++ b/src/main/java/org/graylog2/syslog4j/SyslogMessageProcessorIF.java
@@ -1,6 +1,7 @@
 package org.graylog2.syslog4j;
 
 import java.io.Serializable;
+import java.util.Date;
 
 /**
  * SyslogMessageProcessorIF provides an extensible interface for writing custom
@@ -19,4 +20,6 @@ public interface SyslogMessageProcessorIF extends Serializable {
     public byte[] createPacketData(byte[] header, byte[] message, int start, int length);
 
     public byte[] createPacketData(byte[] header, byte[] message, int start, int length, byte[] splitBeginText, byte[] splitEndText);
+
+    public String createSyslogHeader(int facility, int level, String localName, boolean sendLocalName, Date datetime);
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslog.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslog.java
@@ -288,14 +288,8 @@ public abstract class AbstractSyslog implements SyslogIF {
         byte[] m = SyslogUtility.getBytes(this.syslogConfig, message);
 
         int mLength = m.length;
-        int hLength = h.length;
-        int expectedMinLength = this.syslogConfig.getMinMessageLength();
-        
-        if (mLength < expectedMinLength) {
-        	throw new SyslogRuntimeException("Message length is: " + String.valueOf(mLength) + " but expected to be at least: " + String.valueOf(expectedMinLength));
-        }
 
-        int availableLen = this.syslogConfig.getMaxMessageLength() - hLength;
+        int availableLen = this.syslogConfig.getMaxMessageLength() - h.length;
 
         if (this.syslogConfig.isTruncateMessage()) {
             if (availableLen > 0 && mLength > availableLen) {

--- a/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfig.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfig.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.graylog2.syslog4j.SyslogBackLogHandlerIF;
+import org.graylog2.syslog4j.SyslogConstants;
 import org.graylog2.syslog4j.SyslogMessageModifierIF;
 import org.graylog2.syslog4j.SyslogRuntimeException;
 import org.graylog2.syslog4j.impl.backlog.printstream.SystemErrSyslogBackLogHandler;
@@ -45,6 +46,7 @@ public abstract class AbstractSyslogConfig implements AbstractSyslogConfigIF {
     protected boolean throwExceptionOnInitialize = THROW_EXCEPTION_ON_INITIALIZE_DEFAULT;
 
     protected int maxMessageLength = MAX_MESSAGE_LENGTH_DEFAULT;
+    protected int minMessageLength = 0;
     protected byte[] splitMessageBeginText = SPLIT_MESSAGE_BEGIN_TEXT_DEFAULT.getBytes();
     protected byte[] splitMessageEndText = SPLIT_MESSAGE_END_TEXT_DEFAULT.getBytes();
 
@@ -126,6 +128,14 @@ public abstract class AbstractSyslogConfig implements AbstractSyslogConfigIF {
 
     public void setMaxMessageLength(int maxMessageLength) {
         this.maxMessageLength = maxMessageLength;
+    }
+    
+    public int getMinMessageLength() {
+        return this.minMessageLength;
+    }
+
+    public void setMinMessageLength(int minMessageLength) {
+        this.minMessageLength = minMessageLength;
     }
 
     public boolean isSendLocalTimestamp() {
@@ -370,6 +380,8 @@ public abstract class AbstractSyslogConfig implements AbstractSyslogConfigIF {
 
     public void setUseStructuredData(boolean useStructuredData) {
         this.useStructuredData = useStructuredData;
+        setMaxMessageLength(SyslogConstants.MAX_MESSAGE_LENGTH_RFC5424);
+        setMinMessageLength(SyslogConstants.MIN_MESSAGE_LENGTH_RFC5424);
     }
 
     public Class getSyslogWriterClass() {

--- a/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfig.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfig.java
@@ -46,7 +46,6 @@ public abstract class AbstractSyslogConfig implements AbstractSyslogConfigIF {
     protected boolean throwExceptionOnInitialize = THROW_EXCEPTION_ON_INITIALIZE_DEFAULT;
 
     protected int maxMessageLength = MAX_MESSAGE_LENGTH_DEFAULT;
-    protected int minMessageLength = 0;
     protected byte[] splitMessageBeginText = SPLIT_MESSAGE_BEGIN_TEXT_DEFAULT.getBytes();
     protected byte[] splitMessageEndText = SPLIT_MESSAGE_END_TEXT_DEFAULT.getBytes();
 
@@ -128,14 +127,6 @@ public abstract class AbstractSyslogConfig implements AbstractSyslogConfigIF {
 
     public void setMaxMessageLength(int maxMessageLength) {
         this.maxMessageLength = maxMessageLength;
-    }
-    
-    public int getMinMessageLength() {
-        return this.minMessageLength;
-    }
-
-    public void setMinMessageLength(int minMessageLength) {
-        this.minMessageLength = minMessageLength;
     }
 
     public boolean isSendLocalTimestamp() {
@@ -381,7 +372,6 @@ public abstract class AbstractSyslogConfig implements AbstractSyslogConfigIF {
     public void setUseStructuredData(boolean useStructuredData) {
         this.useStructuredData = useStructuredData;
         setMaxMessageLength(SyslogConstants.MAX_MESSAGE_LENGTH_RFC5424);
-        setMinMessageLength(SyslogConstants.MIN_MESSAGE_LENGTH_RFC5424);
     }
 
     public Class getSyslogWriterClass() {

--- a/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfigIF.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfigIF.java
@@ -62,4 +62,8 @@ public interface AbstractSyslogConfigIF extends SyslogConfigIF {
      * @param maxQueueSize
      */
     public void setMaxQueueSize(int maxQueueSize);
+   
+    public int getMinMessageLength();
+
+    public void setMinMessageLength(int minMessageLength);
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfigIF.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfigIF.java
@@ -62,8 +62,4 @@ public interface AbstractSyslogConfigIF extends SyslogConfigIF {
      * @param maxQueueSize
      */
     public void setMaxQueueSize(int maxQueueSize);
-   
-    public int getMinMessageLength();
-
-    public void setMinMessageLength(int minMessageLength);
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/message/processor/AbstractSyslogMessageProcessor.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/message/processor/AbstractSyslogMessageProcessor.java
@@ -1,8 +1,6 @@
 package org.graylog2.syslog4j.impl.message.processor;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
 
 import org.graylog2.syslog4j.SyslogConstants;
 import org.graylog2.syslog4j.SyslogMessageProcessorIF;
@@ -74,21 +72,6 @@ public abstract class AbstractSyslogMessageProcessor implements SyslogMessagePro
         buffer.append(">");
     }
 
-    protected void appendLocalTimestamp(StringBuffer buffer) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(SYSLOG_DATEFORMAT, Locale.ENGLISH);
-
-        String datePrefix = dateFormat.format(new Date());
-
-        int pos = buffer.length() + 4;
-
-        buffer.append(datePrefix);
-
-        //  RFC 3164 requires leading space for days 1-9
-        if (buffer.charAt(pos) == '0') {
-            buffer.setCharAt(pos, ' ');
-        }
-    }
-
     protected void appendLocalName(StringBuffer buffer, String localName) {
         if (localName != null) {
             buffer.append(localName);
@@ -99,20 +82,7 @@ public abstract class AbstractSyslogMessageProcessor implements SyslogMessagePro
 
         buffer.append(' ');
     }
-
-    public String createSyslogHeader(int facility, int level, String localName, boolean sendLocalTimestamp, boolean sendLocalName) {
-        StringBuffer buffer = new StringBuffer();
-
-        appendPriority(buffer, facility, level);
-
-        if (sendLocalTimestamp) {
-            appendLocalTimestamp(buffer);
-        }
-
-        if (sendLocalName) {
-            appendLocalName(buffer, localName);
-        }
-
-        return buffer.toString();
-    }
+    
+    protected abstract void appendTimestamp(StringBuffer buffer, Date datetime);
+    
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/message/processor/SyslogMessageProcessor.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/message/processor/SyslogMessageProcessor.java
@@ -1,5 +1,9 @@
 package org.graylog2.syslog4j.impl.message.processor;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
 
 /**
  * SyslogMessageProcessor wraps AbstractSyslogMessageProcessor.
@@ -32,4 +36,67 @@ public class SyslogMessageProcessor extends AbstractSyslogMessageProcessor {
     public static SyslogMessageProcessor getDefault() {
         return defaultInstance;
     }
+
+    /* (non-Javadoc)
+     * @see org.graylog2.syslog4j.impl.message.processor.AbstractSyslogMessageProcessor#appendTimestamp(java.lang.StringBuffer, java.util.Date)
+     * 
+     * This is compatible with BSD protocol
+     */
+    @Override
+    public void appendTimestamp(StringBuffer buffer, Date datetime) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(SYSLOG_DATEFORMAT, Locale.ENGLISH);
+
+        String datePrefix = dateFormat.format(datetime);
+
+        int pos = buffer.length() + 4;
+
+        buffer.append(datePrefix);
+
+        //  RFC 3164 requires leading space for days 1-9
+        if (buffer.charAt(pos) == '0') {
+            buffer.setCharAt(pos, ' ');
+        }
+
+    }
+
+    /* (non-Javadoc)
+     * @see org.graylog2.syslog4j.SyslogMessageProcessorIF#createSyslogHeader(int, int, java.lang.String, boolean, boolean)
+     * 
+     * This is compatible with BSD protocol
+     */
+    public String createSyslogHeader(int facility, int level, String localName, boolean sendLocalTimestamp, boolean sendLocalName) {
+        StringBuffer buffer = new StringBuffer();
+
+        appendPriority(buffer, facility, level);
+
+        if (sendLocalTimestamp) {
+            appendTimestamp(buffer, new Date());
+        }
+
+        if (sendLocalName) {
+            appendLocalName(buffer, localName);
+        }
+
+        return buffer.toString();
+    }
+
+    /* (non-Javadoc)
+     * @see org.graylog2.syslog4j.SyslogMessageProcessorIF#createSyslogHeader(int, int, java.lang.String, boolean, java.util.Date)
+     * 
+     * This is compatible with BSD protocol
+     */
+    public String createSyslogHeader(int facility, int level, String localName, boolean sendLocalName, Date datetime) {
+        StringBuffer buffer = new StringBuffer();
+
+        appendPriority(buffer, facility, level);
+
+        appendTimestamp(buffer, datetime);
+
+        if (sendLocalName) {
+            appendLocalName(buffer, localName);
+        }
+
+        return buffer.toString();
+    }
+
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/multiple/MultipleSyslog.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/multiple/MultipleSyslog.java
@@ -1,5 +1,7 @@
 package org.graylog2.syslog4j.impl.multiple;
 
+import java.util.Date;
+
 import org.graylog2.syslog4j.Syslog;
 import org.graylog2.syslog4j.SyslogConfigIF;
 import org.graylog2.syslog4j.SyslogConstants;
@@ -171,4 +173,9 @@ public class MultipleSyslog implements SyslogIF {
     public String getProtocol() {
         return this.syslogProtocol;
     }
+
+	public void log(int level, String message, Date datetime) {
+
+	}
+
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/net/tcp/TCPNetSyslogConfig.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/net/tcp/TCPNetSyslogConfig.java
@@ -45,6 +45,17 @@ public class TCPNetSyslogConfig extends AbstractNetSyslogConfig implements TCPNe
 
     protected int freshConnectionInterval = TCP_FRESH_CONNECTION_INTERVAL_DEFAULT;
 
+	/**
+	 * useFrameHeader flag enables frame header.
+	 * 
+	 * Frame header is sometimes used when writing the syslog message (for example in syslog-ng server syslog() driver).
+	 * It does not allow delimiterSequence; its structure is : digit(size of message byte array) + space + syslog message  
+	 * e.g. where the size of message (byte array) is 89:
+	 * 89 <165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473]
+	 * 
+	 */
+	private boolean useFrameHeader;
+
     public TCPNetSyslogConfig() {
         initialize();
     }
@@ -149,6 +160,14 @@ public class TCPNetSyslogConfig extends AbstractNetSyslogConfig implements TCPNe
     public void setFreshConnectionInterval(int freshConnectionInterval) {
         this.freshConnectionInterval = freshConnectionInterval;
     }
+    
+    public void setUseFrameHeader(boolean useFrameHeader) {
+		this.useFrameHeader = useFrameHeader;
+	}
+
+	public boolean isUseFrameHeader() {
+		return this.useFrameHeader;
+	}
 
     public Class getSyslogWriterClass() {
         return TCPNetSyslogWriter.class;

--- a/src/main/java/org/graylog2/syslog4j/impl/net/tcp/TCPNetSyslogConfigIF.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/net/tcp/TCPNetSyslogConfigIF.java
@@ -45,4 +45,8 @@ public interface TCPNetSyslogConfigIF extends AbstractNetSyslogConfigIF {
     public int getFreshConnectionInterval();
 
     public void setFreshConnectionInterval(int interval);
+
+    public void setUseFrameHeader(boolean useFrameHeader);
+    
+	public boolean isUseFrameHeader();
 }

--- a/src/main/java/org/graylog2/syslog4j/impl/unix/socket/UnixSocketSyslog.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/unix/socket/UnixSocketSyslog.java
@@ -1,6 +1,7 @@
 package org.graylog2.syslog4j.impl.unix.socket;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import org.graylog2.syslog4j.SyslogRuntimeException;
 import org.graylog2.syslog4j.impl.AbstractSyslog;
@@ -39,6 +40,12 @@ public class UnixSocketSyslog extends AbstractSyslog {
             System.arraycopy(sunPath.getBytes(), 0, this.sun_path, 0, sunPath.length());
             System.arraycopy(ZERO_BYTE, 0, this.sun_path, sunPath.length(), 1);
         }
+
+		@Override
+		protected List getFieldOrder() {
+			// TODO Auto-generated method stub
+			return null;
+		}
     }
 
     protected interface CLibrary extends Library {

--- a/src/main/java/org/graylog2/syslog4j/impl/unix/socket/UnixSocketSyslog.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/unix/socket/UnixSocketSyslog.java
@@ -43,8 +43,7 @@ public class UnixSocketSyslog extends AbstractSyslog {
 
 		@Override
 		protected List getFieldOrder() {
-			// TODO Auto-generated method stub
-			return null;
+			return Collections.emptyList();
 		}
     }
 


### PR DESCRIPTION
Implemented compatibility with frame header. Frame header is for instance used by syslog() driver in syslog-ng server and is used to support RFC5424.