### PR TITLE
Issue #8 - Use SyslogServerConfigIF instead of AbstractSyslogServerConfig

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/AbstractSyslogServer.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/AbstractSyslogServer.java
@@ -96,21 +96,14 @@ public abstract class AbstractSyslogServer implements SyslogServerIF {
     }
 
     protected String syslogProtocol = null;
-    protected AbstractSyslogServerConfig syslogServerConfig = null;
+    protected SyslogServerConfigIF syslogServerConfig = null;
     protected Thread thread = null;
 
     protected boolean shutdown = false;
 
     public void initialize(String protocol, SyslogServerConfigIF config) throws SyslogRuntimeException {
         this.syslogProtocol = protocol;
-
-        try {
-            this.syslogServerConfig = (AbstractSyslogServerConfig) config;
-
-        } catch (ClassCastException cce) {
-            throw new SyslogRuntimeException(cce);
-        }
-
+        this.syslogServerConfig = config;
         initialize();
     }
 


### PR DESCRIPTION
Issue #8 - Change to use SyslogServerConfigIF instead of AbstractSyslogServerConfig for syslogServerConfig. This allows config items that do not inherit from AbstractSyslogServerConfig to be used.