### PR TITLE
specify the maximum message size for UDP syslog server

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/net/udp/UDPNetSyslogServer.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/net/udp/UDPNetSyslogServer.java
@@ -69,7 +69,7 @@ public class UDPNetSyslogServer extends AbstractSyslogServer {
             return;
         }
 
-        byte[] receiveData = new byte[SyslogConstants.SYSLOG_BUFFER_SIZE];
+        byte[] receiveData = new byte[syslogBufferSize()];
 
         handleInitialize(this);
 
@@ -98,5 +98,12 @@ public class UDPNetSyslogServer extends AbstractSyslogServer {
         }
 
         handleDestroy(this);
+    }
+
+    private int syslogBufferSize(){
+        if (getConfig() instanceof UDPNetSyslogServerConfig){
+            return ((UDPNetSyslogServerConfig) getConfig()).getMaxMessageSize();
+        }
+        return SyslogConstants.SYSLOG_BUFFER_SIZE;
     }
 }

--- a/src/main/java/org/graylog2/syslog4j/server/impl/net/udp/UDPNetSyslogServerConfig.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/net/udp/UDPNetSyslogServerConfig.java
@@ -1,5 +1,6 @@
 package org.graylog2.syslog4j.server.impl.net.udp;
 
+import org.graylog2.syslog4j.SyslogConstants;
 import org.graylog2.syslog4j.server.impl.net.AbstractNetSyslogServerConfig;
 
 /**
@@ -14,6 +15,8 @@ import org.graylog2.syslog4j.server.impl.net.AbstractNetSyslogServerConfig;
  */
 public class UDPNetSyslogServerConfig extends AbstractNetSyslogServerConfig {
     private static final long serialVersionUID = -2005919161187055486L;
+
+    private int maxMessageSize = SyslogConstants.SYSLOG_BUFFER_SIZE;
 
     public UDPNetSyslogServerConfig() {
         //
@@ -30,6 +33,20 @@ public class UDPNetSyslogServerConfig extends AbstractNetSyslogServerConfig {
     public UDPNetSyslogServerConfig(String host, int port) {
         this.host = host;
         this.port = port;
+    }
+
+    public UDPNetSyslogServerConfig(String host, int port, int maxMessageSize) {
+        this.host = host;
+        this.port = port;
+        this.maxMessageSize = maxMessageSize;
+    }
+
+    public int getMaxMessageSize() {
+        return maxMessageSize;
+    }
+
+    public void setMaxMessageSize(int maxMessageSize) {
+        this.maxMessageSize = maxMessageSize;
     }
 
     public Class getSyslogServerClass() {


### PR DESCRIPTION
The UDP server made the ability to specify the maximum size of the message I (the client had the opportunity, the server did not have)